### PR TITLE
Add tracepoint for publish/subscribe serialized message

### DIFF
--- a/rmw_fastrtps_dynamic_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_common.cpp
@@ -25,12 +25,15 @@
 bool
 using_introspection_c_typesupport(const char * typesupport_identifier)
 {
-  return typesupport_identifier == rosidl_typesupport_introspection_c__identifier;
+  return strcmp(
+    typesupport_identifier,
+    rosidl_typesupport_introspection_c__identifier) == 0;
 }
 
 bool
 using_introspection_cpp_typesupport(const char * typesupport_identifier)
 {
-  return typesupport_identifier ==
-         rosidl_typesupport_introspection_cpp::typesupport_identifier;
+  return strcmp(
+    typesupport_identifier,
+    rosidl_typesupport_introspection_cpp::typesupport_identifier) == 0;
 }

--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -108,7 +108,9 @@ __rmw_publish_serialized_message(
   data.type = FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
   data.data = &ser;
   data.impl = nullptr;  // not used when type is FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER
-  TRACETOOLS_TRACEPOINT(rmw_publish, serialized_message);
+  eprosima::fastrtps::Time_t stamp;
+  eprosima::fastrtps::Time_t::now(stamp);
+  TRACETOOLS_TRACEPOINT(rmw_publish, publisher, serialized_message, stamp.to_ns());
   if (!info->data_writer_->write(&data)) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;

--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -108,6 +108,7 @@ __rmw_publish_serialized_message(
   data.type = FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
   data.data = &ser;
   data.impl = nullptr;  // not used when type is FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER
+  TRACETOOLS_TRACEPOINT(rmw_publish, serialized_message);
   if (!info->data_writer_->write(&data)) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -348,7 +348,12 @@ _take_serialized_message(
       break;
     }
   }
-
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(serialized_message),
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
   return RMW_RET_OK;
 }
 


### PR DESCRIPTION
Add trace points to the publisher and subscription serialized message as they were not being outputted previously.
For the publish serialized message, the added trace point is:

rmw_publish
For the subscribe serialized message, the added trace point is:

rmw_take

The implementation for rcl is https://github.com/ymski/rcl/pull/1.
The implementation for rclcpp is https://github.com/ymski/rclcpp/pull/1 .